### PR TITLE
Fix #6

### DIFF
--- a/utopian/src/buffer.rs
+++ b/utopian/src/buffer.rs
@@ -1,6 +1,5 @@
 use ash::vk;
 use gpu_allocator::vulkan::*;
-use std::{cmp, mem, ptr};
 
 use crate::device::*;
 use crate::image::*;
@@ -90,12 +89,12 @@ impl Buffer {
     pub fn update_memory<T: Copy>(&mut self, device: &Device, data: &[T]) {
         unsafe {
             let src = data.as_ptr() as *const u8;
-            let src_bytes = data.len() * mem::size_of::<T>();
+            let src_bytes = data.len() * std::mem::size_of::<T>();
 
             if self.memory_location != gpu_allocator::MemoryLocation::GpuOnly {
                 let dst = self.allocation.mapped_ptr().unwrap().as_ptr() as *mut u8;
                 let dst_bytes = self.allocation.size() as usize;
-                ptr::copy_nonoverlapping(src, dst, cmp::min(src_bytes, dst_bytes));
+                std::ptr::copy_nonoverlapping(src, dst, std::cmp::min(src_bytes, dst_bytes));
             } else {
                 // This is expensive and should not be done in a hot loop
                 let mut staging_buffer = Buffer::create_buffer(
@@ -107,7 +106,7 @@ impl Buffer {
 
                 let dst = staging_buffer.allocation.mapped_ptr().unwrap().as_ptr() as *mut u8;
                 let dst_bytes = staging_buffer.allocation.size() as usize;
-                ptr::copy_nonoverlapping(src, dst, cmp::min(src_bytes, dst_bytes));
+                std::ptr::copy_nonoverlapping(src, dst, std::cmp::min(src_bytes, dst_bytes));
 
                 device.execute_and_submit(|device, cb| {
                     let regions = vk::BufferCopy::builder()

--- a/utopian/src/device.rs
+++ b/utopian/src/device.rs
@@ -4,10 +4,7 @@ use ash::extensions::khr::Swapchain;
 use ash::vk;
 use gpu_allocator::vulkan::*;
 use gpu_allocator::AllocatorDebugSettings;
-use std::{
-    mem,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 pub struct Device {
     pub handle: ash::Device,
@@ -323,7 +320,7 @@ impl Device {
                 pipeline_layout,
                 vk::ShaderStageFlags::ALL,
                 0,
-                mem::size_of_val(&data).try_into().unwrap(),
+                std::mem::size_of_val(&data).try_into().unwrap(),
                 &data as *const _ as *const _,
             );
         }

--- a/utopian/src/device.rs
+++ b/utopian/src/device.rs
@@ -4,7 +4,10 @@ use ash::extensions::khr::Swapchain;
 use ash::vk;
 use gpu_allocator::vulkan::*;
 use gpu_allocator::AllocatorDebugSettings;
-use std::sync::{Arc, Mutex};
+use std::{
+    mem,
+    sync::{Arc, Mutex},
+};
 
 pub struct Device {
     pub handle: ash::Device,
@@ -315,15 +318,13 @@ impl Device {
         data: T,
     ) {
         unsafe {
-            self.handle.cmd_push_constants(
+            (self.handle.fp_v1_0().cmd_push_constants)(
                 command_buffer,
                 pipeline_layout,
                 vk::ShaderStageFlags::ALL,
                 0,
-                std::slice::from_raw_parts(
-                    &data as *const _ as *const u8,
-                    std::mem::size_of_val(&data),
-                ),
+                mem::size_of_val(&data).try_into().unwrap(),
+                &data as *const _ as *const _,
             );
         }
     }

--- a/utopian/src/graph.rs
+++ b/utopian/src/graph.rs
@@ -1,8 +1,5 @@
-use std::{
-    collections::HashMap,
-    mem::{self, MaybeUninit},
-    slice,
-};
+use std::collections::HashMap;
+use std::mem::MaybeUninit;
 
 use ash::vk;
 
@@ -311,8 +308,8 @@ impl PassBuilder {
         // Note: Todo: this can be improved
         unsafe {
             let ptr = data as *const _ as *const MaybeUninit<u8>;
-            let size = mem::size_of::<T>();
-            let data_u8 = slice::from_raw_parts(ptr, size);
+            let size = std::mem::size_of::<T>();
+            let data_u8 = std::slice::from_raw_parts(ptr, size);
 
             assert!(data_u8.len() < MAX_UNIFORMS_SIZE);
 


### PR DESCRIPTION
Fixes #6. In the instances where `std::slice::from_raw_parts` was used to upload bytes that possibly had padding, this was replaced with raw pointers (as copying uninit bytes using pointers is not UB, while using a reference to uninit bytes is). In the case of `UniformData`, since the uninit bytes are stored on the Rust side and not simply uploaded directly, that approach wouldn't cut it, but that's what we have [`MaybeUninit`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) for.

I wasn't sure which import style to use, but I hope I did it somewhat consistent to the existing code. Please let me know if you would like any changes!